### PR TITLE
fix error where deployment has a build dependency.

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -17,7 +17,6 @@ on:
   workflow_dispatch:
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-dotnet.yml
+++ b/.github/workflows/deploy-dotnet.yml
@@ -12,6 +12,21 @@ on:
     paths: src/Application/**
   workflow_dispatch:
 jobs: 
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0
+    
+    - name: Restore dependencies
+      run: dotnet restore ./src/Application/src/RazorPagesTestSample/RazorPagesTestSample.csproj
+    - name: Build
+      run: dotnet build --no-restore ./src/Application/src/RazorPagesTestSample/RazorPagesTestSample.csproj
+
   dockerBuildPush:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
### Workflow Modifications:

* [`.github/workflows/build-dotnet.yml`](diffhunk://#diff-a9fafddd8adf7af4d68b5d23547772dc4554d49d97573b7005537a3952ad0e87L20): Removed the `runs-on` specification from the `build` job.
* [`.github/workflows/deploy-dotnet.yml`](diffhunk://#diff-730ab1ac48e4516a7802480a8ab828644fb441e2d88a7d28995be3a7c60bc26cR15-R29): Added a `build` job with steps to set up .NET, restore dependencies, and build the project.